### PR TITLE
Fix behat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,111 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.4', '8.0' ]
+        moodle-branch: [ 'MOODLE_311_STABLE','MOODLE_400_STABLE' ]
+        database: [ pgsql, mariadb ]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          # none to use phpdbg fallback. Specify pcov (Moodle 3.10 and up) or xdebug to use them instead.
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '7.4', '8.0' ]
-        moodle-branch: [ 'MOODLE_311_STABLE','MOODLE_400_STABLE' ]
+        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_400_STABLE' ]
         database: [ pgsql, mariadb ]
+        exclude:
+          - php: 8.0
+            moodle-branch: MOODLE_39_STABLE
 
     steps:
       - name: Check out repository code

--- a/block_thumblinks_action.php
+++ b/block_thumblinks_action.php
@@ -24,8 +24,6 @@
 
 use block_thumblinks_action\output\thumblinks_action;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Class block_thumblinks_action
  *
@@ -34,6 +32,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class block_thumblinks_action extends block_base {
+    // TODO links seems to be disfunctionnal, they escape real links.
 
     /**
      * Init function
@@ -56,10 +55,16 @@ class block_thumblinks_action extends block_base {
     /**
      * Content for the block
      *
-     * @return \stdClass|string|null
+     * @return stdClass|string|null
      * @throws coding_exception
      */
     public function get_content() {
+        if (!$this->config) {
+            $this->content = (object) [
+                'text' => get_string("contentnoconfig", "block_thumblinks_action")
+            ];
+            return $this->content;
+        }
 
         if ($this->content !== null) {
             return $this->content;
@@ -80,9 +85,9 @@ class block_thumblinks_action extends block_base {
             $this->title = $this->config->title; // Set the title according to the values in the form.
 
             $renderer = $this->page->get_renderer('core');
-            $titles = empty($this->config->thumbtitle) ? [] : $this->config->thumbtitle;
-            $urls = empty($this->config->thumburl) ? [] : $this->config->thumburl;
-            $images = empty($this->config->thumbimage) ? [] : $this->config->thumbimage;
+            $titles = $this->config->thumbtitle ?? [];
+            $urls = $this->config->thumburl ?? [];
+            $images = $this->config->thumbimage ?? [];
 
             $this->content->text = $renderer->render(
                 new thumblinks_action(
@@ -92,7 +97,8 @@ class block_thumblinks_action extends block_base {
                     $this->config->cta,
                     $this->config->ctatitle,
                     $this->context->id
-                ));
+                )
+            );
         }
 
         return $this->content;
@@ -103,7 +109,7 @@ class block_thumblinks_action extends block_base {
      *
      * @return array
      */
-    public function applicable_formats() {
+    public function applicable_formats(): array {
         return array('all' => true);
     }
 
@@ -112,7 +118,7 @@ class block_thumblinks_action extends block_base {
      *
      * @return bool
      */
-    public function instance_allow_multiple() {
+    public function instance_allow_multiple(): bool {
         return true;
     }
 
@@ -121,7 +127,7 @@ class block_thumblinks_action extends block_base {
      *
      * @return bool
      */
-    public function has_config() {
+    public function has_config(): bool {
         return false;
     }
 
@@ -136,19 +142,22 @@ class block_thumblinks_action extends block_base {
         $config = clone($data);
         // Save the images.
         if ($config->thumbimage) {
-            foreach ($config->thumbimage as $index => $images) {
-                file_save_draft_area_files($images,
+            foreach ($config->thumbimage as $index => $image) {
+                file_save_draft_area_files(
+                    $image,
                     $this->context->id,
                     'block_thumblinks_action',
                     'images',
                     $index,
-                    array('subdirs' => true));
+                    array('subdirs' => true)
+                );
             }
             // Here we make sure we copy the image id into the
             // block parameter. This is then used in save_data
-            // to setup the block to the right image.
+            // to set up the block to the right image.
             $fs = get_file_storage();
-            $files = $fs->get_area_files($this->context->id,
+            $files = $fs->get_area_files(
+                $this->context->id,
                 'block_thumblinks_action',
                 'images'
             );
@@ -167,7 +176,7 @@ class block_thumblinks_action extends block_base {
      *
      * @return bool
      */
-    public function instance_delete() {
+    public function instance_delete(): bool {
         $fs = get_file_storage();
         $fs->delete_area_files($this->context->id, 'block_thumblinks_action');
         return true;
@@ -179,7 +188,7 @@ class block_thumblinks_action extends block_base {
      * @param int $fromid the id number of the block instance to copy from
      * @return boolean
      */
-    public function instance_copy($fromid) {
+    public function instance_copy($fromid): bool {
         global $DB;
 
         $fromcontext = context_block::instance($fromid);
@@ -201,13 +210,16 @@ class block_thumblinks_action extends block_base {
                     'block_thumblinks_action',
                     'images',
                     $itemid,
-                    array('subdirs' => true));
+                    array('subdirs' => true)
+                );
                 file_save_draft_area_files(
                     $draftitemid,
                     $this->context->id,
                     'block_thumblinks_action',
-                    'images', $itemid,
-                    array('subdirs' => true));
+                    'images',
+                    $itemid,
+                    array('subdirs' => true)
+                );
             }
         }
         return true;

--- a/classes/output/thumblinks_action.php
+++ b/classes/output/thumblinks_action.php
@@ -23,13 +23,13 @@
  */
 
 namespace block_thumblinks_action\output;
-defined('MOODLE_INTERNAL') || die();
 
-global $CFG;
-
+use coding_exception;
+use moodle_exception;
 use moodle_url;
 use renderable;
 use renderer_base;
+use stdClass;
 use templatable;
 
 /**
@@ -70,11 +70,11 @@ class thumblinks_action implements renderable, templatable {
      * @param array $thumbtitles
      * @param array $thumbimages
      * @param array $thumburls
-     * @param \moodle_url $cta
+     * @param moodle_url $cta
      * @param string $ctatitle
      * @param int $blockcontextid
-     * @throws \coding_exception
-     * @throws \moodle_exception
+     * @throws coding_exception
+     * @throws moodle_exception
      */
     public function __construct($thumbtitles, $thumbimages, $thumburls, $cta, $ctatitle, $blockcontextid) {
         $thumbtitlecount = empty($thumbtitles) ? 0 : count($thumbtitles);
@@ -83,25 +83,25 @@ class thumblinks_action implements renderable, templatable {
         $fs = get_file_storage();
 
         for ($itemi = 0; $itemi < $numthumbnails; $itemi++) {
-            $thumbnail = new \stdClass();
-            $thumbnail->title = !empty($thumbtitles[$itemi]) ? $thumbtitles[$itemi] : '';
-            $thumbnail->url = !empty($thumburls[$itemi]) ? $thumburls[$itemi] : null;
+            $thumbnail = new stdClass();
+            $thumbnail->title = $thumbtitles[$itemi] ?? '';
+            $thumbnail->url = $thumburls[$itemi] ?? null;
             $allfiles = $fs->get_area_files($blockcontextid, 'block_thumblinks_action', 'images', $itemi);
             foreach ($allfiles as $file) {
                 if ($file->is_valid_image()) {
-                    $thumbnail->image = \moodle_url::make_pluginfile_url(
+                    $thumbnail->image = moodle_url::make_pluginfile_url(
                         $blockcontextid,
                         'block_thumblinks_action',
                         'images',
                         $itemi,
                         $file->get_filepath(),
                         $file->get_filename()
-                    )->out();
+                    )->out(false);
                 }
             }
             $this->thumbnails[] = $thumbnail;
         }
-        $this->cta = new \moodle_url($cta);
+        $this->cta = new moodle_url($cta);
         $this->ctatitle = $ctatitle;
     }
 
@@ -109,13 +109,13 @@ class thumblinks_action implements renderable, templatable {
      * Export for mustache template
      *
      * @param renderer_base $output
-     * @return array|\stdClass
+     * @return array
      */
-    public function export_for_template(renderer_base $output) {
+    public function export_for_template(renderer_base $output): array {
         $exportedvalue = [
             'thumbnails' => $this->thumbnails,
             'ctatitle' => $this->ctatitle,
-            'cta' => ($this->cta) ? $this->cta->out() : ''
+            'cta' => ($this->cta) ? $this->cta->out(false) : ''
         ];
         return $exportedvalue;
     }

--- a/classes/output/thumbnail.php
+++ b/classes/output/thumbnail.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Thumbnail inside the thumblinks action block
+ *
+ * @package    block_thumblinks_action
+ * @copyright 2022 - CALL Learning - Martin CORNU-MANSUY <martin@call-learning.fr>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace block_thumblinks_action;
+
+use moodle_url;
+use renderable;
+use renderer_base;
+use templatable;
+
+/**
+ * A class to represent a thumbnail in the thumblink_action moodle block.
+ */
+class thumbnail {
+    /** @var string the title of the thumbnail. */
+    private $title;
+
+    /** @var moodle_url the link of the thumbnail. */
+    private $link;
+
+    /** @var moodle_url the image url of the thumbnail. */
+    private $imageurl;
+
+    /**
+     * Constructor.
+     *
+     * @param string $title
+     * @param moodle_url $link
+     * @param moodle_url $imageurl
+     */
+    public function __construct($title, $link, $imageurl) {
+        $this->link = $link;
+        $this->title = $title;
+        $this->imageurl = $imageurl;
+    }
+
+    /**
+     * Gets the title of the thumbnail.
+     *
+     * @return string
+     */
+    public function gettitle(): string {
+        return $this->title;
+    }
+
+    /**
+     * Gets the imageurl of the thumbnail.
+     *
+     * @return string
+     */
+    public function getimageurl(): string {
+        return $this->imageurl;
+    }
+
+    /**
+     * Gets the link of the thumbnail.
+     *
+     * @return string
+     */
+    public function getlink(): string {
+        return $this->link;
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -21,9 +21,10 @@
  * @copyright 2020 - CALL Learning - Laurent David <laurent@call-learning.fr>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
 namespace block_thumblinks_action\privacy;
 
-defined('MOODLE_INTERNAL') || die();
+use core_privacy\local\metadata\null_provider;
 
 /**
  * Privacy Subsystem for block_thumblinks_action implementing null_provider.
@@ -31,7 +32,7 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright 2020 - CALL Learning - Laurent David <laurent@call-learning.fr>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class provider implements \core_privacy\local\metadata\null_provider {
+class provider implements null_provider {
 
     /**
      * Get the language string identifier with the component's language
@@ -39,7 +40,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return  string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/edit_form.php
+++ b/edit_form.php
@@ -29,7 +29,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class block_thumblinks_action_edit_form extends block_edit_form {
-
     /**
      * Form definition
      *
@@ -37,7 +36,6 @@ class block_thumblinks_action_edit_form extends block_edit_form {
      * @throws coding_exception
      */
     protected function specific_definition($mform) {
-
         // Section header title according to language file.
         $mform->addElement('header', 'configheader', get_string('blocksettings', 'block'));
 
@@ -49,14 +47,13 @@ class block_thumblinks_action_edit_form extends block_edit_form {
         // The CTA Link.
         $mform->addElement('text', 'config_cta', get_string('config:cta', 'block_thumblinks_action'));
         $mform->setDefault('config_cta', '');
-        $mform->setType('config_cta', PARAM_LOCALURL);
+        $mform->setType('config_cta', PARAM_URL);
         // The CTA title.
         $mform->addElement('text', 'config_ctatitle', get_string('config:ctatitle', 'block_thumblinks_action'));
         $mform->setDefault('config_ctatitle', '');
         $mform->setType('config_ctatitle', PARAM_TEXT);
 
         $this->add_thubmnail_elements($mform);
-
     }
 
     /**
@@ -69,8 +66,11 @@ class block_thumblinks_action_edit_form extends block_edit_form {
         $repeatarray = array();
         $repeatedoptions = array();
 
-        $repeatarray[] = $mform->createElement('text', 'config_thumbtitle',
-            get_string('config:thumbtitle', 'block_thumblinks_action'));
+        $repeatarray[] = $mform->createElement(
+            'text',
+            'config_thumbtitle',
+            get_string('config:thumbtitle', 'block_thumblinks_action')
+        );
         $repeatedoptions['config_thumbtitle']['type'] = PARAM_TEXT;
 
         $repeatarray[] = $mform->createElement(
@@ -83,13 +83,18 @@ class block_thumblinks_action_edit_form extends block_edit_form {
         $repeatedoptions['config_thumbimage']['type'] = PARAM_RAW;
 
         // The CTA Link.
-        $repeatarray[] = $mform->createElement('text', 'config_thumburl',
-            get_string('config:thumburl', 'block_thumblinks_action'));
-        $repeatedoptions['config_thumburl']['type'] = PARAM_LOCALURL;
+        $repeatarray[] = $mform->createElement(
+            'text',
+            'config_thumburl',
+            get_string('config:thumburl', 'block_thumblinks_action')
+        );
+        $repeatedoptions['config_thumburl']['type'] = PARAM_URL;
 
         $numthumbnails = $this->get_current_repeats();
 
-        $this->repeat_elements($repeatarray, $numthumbnails,
+        $this->repeat_elements(
+            $repeatarray,
+            $numthumbnails,
             $repeatedoptions,
             'thumb_repeats',
             'thumb_add_fields',
@@ -99,7 +104,6 @@ class block_thumblinks_action_edit_form extends block_edit_form {
             'thumb_remove_fields',
             get_string('removelastthumb', 'block_thumblinks_action')
         );
-
     }
 
     /**
@@ -124,16 +128,17 @@ class block_thumblinks_action_edit_form extends block_edit_form {
                 // Here we could try to use the file_get_submitted_draft_itemid, but it expects to have an itemid defined
                 // Which is not what we have right now, we just have a flat list.
                 $param = optional_param_array($fieldname, 0, PARAM_INT);
-                $draftitemid = $param[$index];
                 if (!empty($param[$index])) {
                     $draftitemid = $param[$index];
                 }
-                file_prepare_draft_area($draftitemid,
+                file_prepare_draft_area(
+                    $draftitemid,
                     $this->block->context->id,
                     'block_thumblinks_action',
                     'images',
                     $index,
-                    $this->get_file_manager_options());
+                    $this->get_file_manager_options()
+                );
 
                 $filefields->{$fieldname}[$index] = $draftitemid;
             }
@@ -142,9 +147,11 @@ class block_thumblinks_action_edit_form extends block_edit_form {
     }
 
     /**
-     * Get number of repeats
+     * Get number of repeats.
+     *
+     * @return int the number of repeats.
      */
-    protected function get_current_repeats() {
+    protected function get_current_repeats(): int {
         $thumbtitlecount = empty($this->block->config->thumbtitle) ? 0 : count($this->block->config->thumbtitle);
         $thumbimgcount = empty($this->block->config->thumbimage) ? 0 : count($this->block->config->thumbimage);
         return max(1, $thumbtitlecount, $thumbimgcount);
@@ -155,7 +162,7 @@ class block_thumblinks_action_edit_form extends block_edit_form {
      *
      * @return array
      */
-    protected function get_file_manager_options() {
+    protected function get_file_manager_options(): array {
         return array('subdirs' => 0,
             'maxbytes' => FILE_AREA_MAX_BYTES_UNLIMITED,
             'maxfiles' => 1,
@@ -189,14 +196,18 @@ class block_thumblinks_action_edit_form extends block_edit_form {
      * @return int no of repeats of element in this page
      * @throws coding_exception
      */
-    public function repeat_elements($elementobjs, $repeats, $options, $repeathiddenname,
+    public function repeat_elements(
+        $elementobjs,
+        $repeats,
+        $options,
+        $repeathiddenname,
         $addfieldsname,
         $addfieldsno = 5,
         $addstring = null,
         $addbuttoninside = false,
         $deletefieldsname = null,
         $deletestring = null
-    ) {
+    ): int {
         $repeats = $this->optional_param($repeathiddenname, $repeats, PARAM_INT);
         if ($deletefieldsname) {
             $removefields = $this->optional_param($deletefieldsname, '', PARAM_TEXT);
@@ -249,16 +260,15 @@ class block_thumblinks_action_edit_form extends block_edit_form {
                     $realelementname = $elementname . "[$i]";
                 }
                 foreach ($elementoptions as $option => $params) {
-
                     switch ($option) {
-                        case 'default' :
+                        case 'default':
                             $mform->setDefault($realelementname, str_replace('{no}', $i + 1, $params));
                             break;
-                        case 'helpbutton' :
+                        case 'helpbutton':
                             $params = array_merge(array($realelementname), $params);
                             call_user_func_array(array(&$mform, 'addHelpButton'), $params);
                             break;
-                        case 'disabledif' :
+                        case 'disabledif':
                             foreach ($namecloned as $num => $name) {
                                 if ($params[0] == $name) {
                                     $params[0] = $params[0] . "[$i]";
@@ -268,7 +278,7 @@ class block_thumblinks_action_edit_form extends block_edit_form {
                             $params = array_merge(array($realelementname), $params);
                             call_user_func_array(array(&$mform, 'disabledIf'), $params);
                             break;
-                        case 'hideif' :
+                        case 'hideif':
                             foreach ($namecloned as $num => $name) {
                                 if ($params[0] == $name) {
                                     $params[0] = $params[0] . "[$i]";
@@ -278,7 +288,7 @@ class block_thumblinks_action_edit_form extends block_edit_form {
                             $params = array_merge(array($realelementname), $params);
                             call_user_func_array(array(&$mform, 'hideIf'), $params);
                             break;
-                        case 'rule' :
+                        case 'rule':
                             if (is_string($params)) {
                                 $params = array(null, $params, null, 'client');
                             }
@@ -294,7 +304,7 @@ class block_thumblinks_action_edit_form extends block_edit_form {
                             $mform->setExpanded($realelementname, $params);
                             break;
 
-                        case 'advanced' :
+                        case 'advanced':
                             $mform->setAdvanced($realelementname, $params);
                             break;
                     }

--- a/edit_form.php
+++ b/edit_form.php
@@ -128,6 +128,7 @@ class block_thumblinks_action_edit_form extends block_edit_form {
                 // Here we could try to use the file_get_submitted_draft_itemid, but it expects to have an itemid defined
                 // Which is not what we have right now, we just have a flat list.
                 $param = optional_param_array($fieldname, 0, PARAM_INT);
+                $draftitemid = null;
                 if (!empty($param[$index])) {
                     $draftitemid = $param[$index];
                 }

--- a/lang/en/block_thumblinks_action.php
+++ b/lang/en/block_thumblinks_action.php
@@ -22,6 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['contentnoconfig'] = 'Configure the block to see your thumbnail links & action.';
 $string['addmorethumbnails'] = 'Add {no} more thumbnails';
 $string['blockstring'] = 'Block string';
 $string['config:title'] = 'Title';
@@ -35,4 +36,3 @@ $string['pluginname'] = 'Thumbnail links and action';
 $string['removelastthumb'] = 'Remove last thumbnail';
 $string['thumblinks_action:addinstance'] = 'Add a thumblinks_action block';
 $string['thumblinks_action:myaddinstance'] = 'Add a thumblinks_action block to my moodle';
-

--- a/lib.php
+++ b/lib.php
@@ -29,18 +29,18 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+use core\session\manager;
 
 /**
  * Get plugin file for this block (identical to HTML block)
  *
- * @param stdClass $course course object
- * @param stdClass $birecordorcm block instance record
- * @param stdClass $context context object
- * @param string $filearea file area
- * @param array $args extra arguments
- * @param bool $forcedownload whether or not force download
- * @param array $options additional options affecting the file serving
+ * @param stdClass $course Course object
+ * @param stdClass $birecordorcm Block instance record
+ * @param stdClass $context Context object
+ * @param string $filearea File area
+ * @param array $args Extra arguments
+ * @param bool $forcedownload Whether force download
+ * @param array $options Additional options affecting the file serving
  * @return void
  * @throws coding_exception
  * @throws moodle_exception
@@ -49,8 +49,15 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @category  files
  */
-function block_thumblinks_action_pluginfile($course, $birecordorcm, $context, $filearea, $args, $forcedownload,
-    array $options = array()) {
+function block_thumblinks_action_pluginfile(
+    $course,
+    $birecordorcm,
+    $context,
+    $filearea,
+    $args,
+    $forcedownload,
+    array $options = array()
+) {
     global $CFG, $USER;
 
     if ($context->contextlevel != CONTEXT_BLOCK) {
@@ -87,7 +94,7 @@ function block_thumblinks_action_pluginfile($course, $birecordorcm, $context, $f
     $itemid = array_shift($args);
     $filepath = $args ? '/' . implode('/', $args) . '/' : '/';
 
-    if (!$file = $fs->get_file($context->id, 'block_thumblinks_action', $filearea, $itemid, $filepath, $filename) or
+    if ((!$file = $fs->get_file($context->id, 'block_thumblinks_action', $filearea, $itemid, $filepath, $filename)) ||
         $file->is_directory()) {
         send_file_not_found();
     }
@@ -99,7 +106,7 @@ function block_thumblinks_action_pluginfile($course, $birecordorcm, $context, $f
     } else {
         $forcedownload = true;
     }
-    \core\session\manager::write_close();
+    manager::write_close();
     send_stored_file($file, null, 0, $forcedownload, $options);
 }
 
@@ -116,9 +123,9 @@ function block_thumblinks_action_global_db_replace($search, $replace) {
     $instances = $DB->get_recordset('block_instances', array('blockname' => 'mcms'));
     foreach ($instances as $instance) {
         $config = unserialize(base64_decode($instance->configdata));
-        if (isset($config->text) and is_string($config->text)) {
+        if (isset($config->text) && is_string($config->text)) {
             $config->text = str_replace($search, $replace, $config->text);
-            $DB->update_record('block_instances', [
+            $DB->update_record('block_instances', (object) [
                 'id' => $instance->id,
                 'configdata' => base64_encode(serialize($config)),
                 'timemodified' => time()]);
@@ -135,7 +142,7 @@ function block_thumblinks_action_global_db_replace($search, $replace) {
  * @return array The itemid and the filepath inside the $args path, for the defined filearea.
  */
 function block_thumblinks_action_get_path_from_pluginfile(string $filearea, array $args): array {
-    // This block never has an itemid (the number represents the revision but it's not stored in database).
+    // This block never has an itemid (the number represents the revision, but it's not stored in database).
     array_shift($args);
 
     $itemid = 0;

--- a/templates/thumblinks_action.mustache
+++ b/templates/thumblinks_action.mustache
@@ -19,8 +19,19 @@
 
     This template renders the main content area for the mcms block.
 
-    Example context (json):
-    {}
+    Example context (json): {
+        "thumbnails":
+            [
+                {
+                    "title":"Heeyyyy",
+                    "url":"https://moodle.org",
+                    "image":"http:\/\/moodlepg.local\/pluginfile.php\/44\/block_thumblinks_action\/images\/0\/Peacock.png"
+                    }
+                ],
+         "ctatitle":"Youtube",
+         "cta":"https://youtube.com"
+         }
+
 }}
 
 <div id="block-thumblinks-action-{{uniqid}}" class="block-thumblinks-action block-cards">

--- a/templates/thumblinks_action.mustache
+++ b/templates/thumblinks_action.mustache
@@ -47,7 +47,7 @@
         </div>
     </div>
     <div class="container text-center mt-5">
-        <a class="btn btn-primary" href="{{ cta }}">
+        <a class="btn btn-primary cta" href="{{ cta }}">
             {{ ctatitle }}
         </a>
     </div>

--- a/tests/behat/behat_block_thumblinks_action.php
+++ b/tests/behat/behat_block_thumblinks_action.php
@@ -1,0 +1,65 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File containing a class allowing set editing mode on either on moodle 3 & moodle 4.
+ *
+ * @package     block_thumblinks_action
+ * @copyright   2022 - CALL Learning
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author      Martin CORNU-MANSUY <martin@call-learning>
+ */
+
+/**
+ * A patch to make "I turn editing mode on" compatible with moodle 3.
+ *
+ * @package     block_thumblinks_action
+ * @copyright   2022 - CALL Learning
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author      Martin CORNU-MANSUY <martin@call-learning>
+ */
+class behat_block_thumblinks_action extends behat_base {
+
+    /**
+     * Turn on editing mode in moodle compatible with version 3 and 4.
+     *
+     * @Given I set editing mode on
+     */
+    public function i_set_editing_mode_on() {
+        global $CFG;
+        require_once($CFG->dirroot . "/lib/environmentlib.php");
+        $release = intval(get_config('', 'release')[0]);
+        if (normalize_version($release) > 3) {
+            $this->execute('behat_navigation::i_turn_editing_mode_on', []);
+        } else {
+            $this->execute('behat_general::i_click_on', ["Customise this page", "button"]);
+        }
+    }
+
+    /**
+     * Checks if the current url is matching with the specified one.
+     *
+     * @Then The url should match :expectedurl
+     * @param string $expectedurl The expected url
+     * @throws coding_exception If the actual url doesn't match with the expected one.
+     */
+    public function the_url_should_match($expectedurl) {
+        $actualurl = $this->getSession()->getCurrentUrl();
+        if ($expectedurl != $actualurl) {
+            throw new coding_exception("The actual url $actualurl doesn't match the expected url $expectedurl");
+        }
+    }
+}

--- a/tests/behat/behat_block_thumblinks_action.php
+++ b/tests/behat/behat_block_thumblinks_action.php
@@ -24,7 +24,7 @@
  */
 
 /**
- * A patch to make "I turn editing mode on" compatible with moodle 3.
+ *  Behat customisations for the bloc
  *
  * @package     block_thumblinks_action
  * @copyright   2022 - CALL Learning
@@ -32,34 +32,37 @@
  * @author      Martin CORNU-MANSUY <martin@call-learning>
  */
 class behat_block_thumblinks_action extends behat_base {
-
     /**
-     * Turn on editing mode in moodle compatible with version 3 and 4.
+     * Return the list of partial named selectors for this plugin.
      *
-     * @Given I set editing mode on
+     * @return behat_component_named_selector[]
      */
-    public function i_set_editing_mode_on() {
-        global $CFG;
-        require_once($CFG->dirroot . "/lib/environmentlib.php");
-        $release = intval(get_config('', 'release')[0]);
-        if (normalize_version($release) > 3) {
-            $this->execute('behat_navigation::i_turn_editing_mode_on', []);
-        } else {
-            $this->execute('behat_general::i_click_on', ["Customise this page", "button"]);
-        }
+    public static function get_partial_named_selectors(): array {
+        return [
+            new behat_component_named_selector(
+                'Thumbnail link', [
+                    <<<XPATH
+    .//a[contains(@class,'thumbnail') and contains(normalize-space(.),%locator%)]
+XPATH
+                ]
+            ),
+        ];
     }
 
     /**
-     * Checks if the current url is matching with the specified one.
+     * Return a list of the exact named selectors for the component.
      *
-     * @Then The url should match :expectedurl
-     * @param string $expectedurl The expected url
-     * @throws coding_exception If the actual url doesn't match with the expected one.
+     * @return behat_component_named_selector[]
      */
-    public function the_url_should_match($expectedurl) {
-        $actualurl = $this->getSession()->getCurrentUrl();
-        if ($expectedurl != $actualurl) {
-            throw new coding_exception("The actual url $actualurl doesn't match the expected url $expectedurl");
-        }
+    public static function get_exact_named_selectors(): array {
+        return [
+            new behat_component_named_selector('Link with URL', [
+                "//div[contains(@class,'block-thumblinks-action')]//a[contains(@href, %locator%)]",
+            ]),
+            new behat_component_named_selector('Link with Background', [
+                "//div[contains(@class,'block-thumblinks-action')]//a[contains(@style, %locator%)]",
+            ]),
+        ];
     }
+
 }

--- a/tests/behat/following_links.feature
+++ b/tests/behat/following_links.feature
@@ -19,10 +19,9 @@ Feature: Adding and configuring Thumbnails links action block and following thei
     Given I set the field "Title" to "Test thumbnail link"
     And I set the field "Thumbnail 1 Title" to "First Training"
     And I set the field "Thumbnail 1 URL" to "https://moodle.org/"
-    When I press "Save changes"
-    Then "//*[contains(@class, 'block-thumblinks-action')]//a[1]" "xpath_element" should exist
-    Given I click on "//*[contains(@class, 'block-thumblinks-action')]//a[1]" "xpath_element"
-    Then the url should match "https://moodle.org/"
+    And I press "Save changes"
+    Then "First Training" "block_thumblinks_action > Thumbnail link" should exist
+    And "moodle.org" "block_thumblinks_action > Link with URL" should exist
 
   @javascript
   Scenario: Setting an action link and get into it
@@ -38,6 +37,4 @@ Feature: Adding and configuring Thumbnails links action block and following thei
     And I set the field "CALL to Action Title" to "Test Action"
     And I set the field "CALL to Action" to "https://moodle.org/"
     When I press "Save changes"
-    Then "//*[contains(@class, 'block-thumblinks-action')]//*[contains(@class, 'btn btn-primary')]" "xpath_element" should exist
-    Given I click on "//*[contains(@class, 'block-thumblinks-action')]//*[contains(@class, 'btn btn-primary')]" "xpath_element"
-    Then the url should match "https://moodle.org/"
+    And "moodle.org" "block_thumblinks_action > Link with URL" should exist

--- a/tests/behat/following_links.feature
+++ b/tests/behat/following_links.feature
@@ -1,0 +1,43 @@
+@block @block_thumblinks_action
+Feature: Adding and configuring Thumbnails links action block and following their links
+  In order to follow the links of the block and use its action
+  As a admin
+  I need to add the Thumbnails links block to the front page
+
+  @javascript
+  Scenario: Setting a thumbnail link and get into it
+    Given I log in as "admin"
+    And I am on site homepage
+    When I turn editing mode on
+    And I add the "Thumbnail links and action" block
+    And I configure the "Thumbnail links and action" block
+    Then I should see "Title"
+    And I should see "CALL to Action"
+    And I should see "CALL to Action Title"
+    And I should see "Thumbnail 1 Title"
+    And I should see "Thumbnail 1 URL"
+    Given I set the field "Title" to "Test thumbnail link"
+    And I set the field "Thumbnail 1 Title" to "First Training"
+    And I set the field "Thumbnail 1 URL" to "https://moodle.org/"
+    When I press "Save changes"
+    Then "//*[contains(@class, 'block-thumblinks-action')]//a[1]" "xpath_element" should exist
+    Given I click on "//*[contains(@class, 'block-thumblinks-action')]//a[1]" "xpath_element"
+    Then the url should match "https://moodle.org/"
+
+  @javascript
+  Scenario: Setting an action link and get into it
+    Given I log in as "admin"
+    And I am on site homepage
+    And I turn editing mode on
+    And I add the "Thumbnail links and action" block
+    When I configure the "Thumbnail links and action" block
+    Then I should see "Title"
+    And I should see "CALL to Action"
+    And I should see "CALL to Action Title"
+    Given I set the field "Title" to "Test action link"
+    And I set the field "CALL to Action Title" to "Test Action"
+    And I set the field "CALL to Action" to "https://moodle.org/"
+    When I press "Save changes"
+    Then "//*[contains(@class, 'block-thumblinks-action')]//*[contains(@class, 'btn btn-primary')]" "xpath_element" should exist
+    Given I click on "//*[contains(@class, 'block-thumblinks-action')]//*[contains(@class, 'btn btn-primary')]" "xpath_element"
+    Then the url should match "https://moodle.org/"

--- a/tests/behat/setup_thumblinks_action_block.feature
+++ b/tests/behat/setup_thumblinks_action_block.feature
@@ -8,7 +8,7 @@ Feature: Adding and configuring Thumbnails links action block
   Scenario: Adding Thumbnails links block and I change the image, this should result in the new image being displayed.
     Given I log in as "admin"
     And I am on site homepage
-    And I turn editing mode on
+    And I set editing mode on
     And I add the "Thumbnail links and action" block
     And I configure the "Thumbnail links and action" block
     Then I should see "Title"
@@ -35,20 +35,22 @@ Feature: Adding and configuring Thumbnails links action block
     And I turn editing mode on
     And I add the "Thumbnail links and action" block
     And I configure the "Thumbnail links and action" block
-    Then I should see "Title"
+    And I should see "Title"
     And I set the field "Title" to "Trainings"
     And I press "Add 1 more thumbnails"
-    Given I set the field "Thumbnail 1 Title" to "First Training"
-    Given I set the field "Thumbnail 1 URL" to "http://www.myurl1.fr"
-    Given I set the field "Thumbnail 2 Title" to "Second Training"
-    Given I set the field "Thumbnail 2 URL" to "http://www.myurl2.fr"
+    And I set the field "Thumbnail 1 Title" to "First Training"
+    And I set the field "Thumbnail 1 URL" to "http://www.myurl1.fr"
+    And I set the field "Thumbnail 2 Title" to "Second Training"
+    And I set the field "Thumbnail 2 URL" to "http://www.myurl2.fr"
     # Issue here (xpath node is not visible and it should be visible)
     # Seems to be due to the fact that we have several filemanagers on the same page and the second one opened
     # does not appear to behat as visible. A workaround here is to save them in sequence.
     And I upload "blocks/thumblinks_action/tests/fixtures/bookmark-new.png" file to "Thumbnail 1 Image" filemanager
     And I press "Save changes"
-    Then "//*[contains(@class, 'block-thumblinks-action')]//a[1][contains(@style, 'bookmark-new.png')]" "xpath_element" should exist
+    And "//*[contains(@class, 'block-thumblinks-action')]//a[1][contains(@style, 'bookmark-new.png')]" "xpath_element" should exist
     And I configure the "Trainings" block
+    # The "((//html//input[./@id = substring-before(//p[normalize-space(.)='Thumbnail 2 Image']/@id, '_label')]//ancestor::*[@data-fieldtype = 'filemanager' or @data-fieldtype = 'filepicker'])[1]/descendant-or-self::div[@class and contains(concat(' ', normalize-space(@class), ' '), ' fp-btn-add ')]/descendant-or-self::*/a | (//html//input[./@id = substring-before(//p[normalize-space(.)='Thumbnail 2 Image']/@id, '_label')]//ancestor::*[@data-fieldtype = 'filemanager' or @data-fieldtype = 'filepicker'])[1]/descendant-or-self::input[@class and contains(concat(' ', normalize-space(@class), ' '), ' fp-btn-choose ')])[1]"
+      # xpath node is not visible and it should be visible.
     And I upload "blocks/thumblinks_action/tests/fixtures/document-edit.png" file to "Thumbnail 2 Image" filemanager
-    And I press "Save changes"
+    When I press "Save changes"
     Then "//*[contains(@class, 'block-thumblinks-action')]//a[2][contains(@style, 'document-edit.png')]" "xpath_element" should exist

--- a/tests/behat/setup_thumblinks_action_block.feature
+++ b/tests/behat/setup_thumblinks_action_block.feature
@@ -4,11 +4,11 @@ Feature: Adding and configuring Thumbnails links action block
   As a admin
   I need to add the Thumbnails links block to the front page
 
-  @javascript @_file_upload @runonly
+  @javascript @_file_upload
   Scenario: Adding Thumbnails links block and I change the image, this should result in the new image being displayed.
     Given I log in as "admin"
     And I am on site homepage
-    And I set editing mode on
+    And I turn editing mode on
     And I add the "Thumbnail links and action" block
     And I configure the "Thumbnail links and action" block
     Then I should see "Title"
@@ -21,12 +21,12 @@ Feature: Adding and configuring Thumbnails links action block
     Given I set the field "Thumbnail 1 URL" to "http://www.myurl1.fr"
     And I upload "blocks/thumblinks_action/tests/fixtures/bookmark-new.png" file to "Thumbnail 1 Image" filemanager
     And I press "Save changes"
-    Then "//*[contains(@class, 'block-thumblinks-action')]//a[1][contains(@style, 'bookmark-new.png')]" "xpath_element" should exist
+    Then "bookmark-new.png" "block_thumblinks_action > Link with Background" should exist
     And I configure the "Trainings" block
     And I delete "bookmark-new.png" from "Thumbnail 1 Image" filemanager
     And I upload "blocks/thumblinks_action/tests/fixtures/document-edit.png" file to "Thumbnail 1 Image" filemanager
     And I press "Save changes"
-    Then "//*[contains(@class, 'block-thumblinks-action')]//a[1][contains(@style, 'document-edit.png')]" "xpath_element" should exist
+    Then "document-edit.png" "block_thumblinks_action > Link with Background" should exist
 
   @javascript @_file_upload
   Scenario: Adding Thumbnails links block and several images
@@ -47,10 +47,10 @@ Feature: Adding and configuring Thumbnails links action block
     # does not appear to behat as visible. A workaround here is to save them in sequence.
     And I upload "blocks/thumblinks_action/tests/fixtures/bookmark-new.png" file to "Thumbnail 1 Image" filemanager
     And I press "Save changes"
-    And "//*[contains(@class, 'block-thumblinks-action')]//a[1][contains(@style, 'bookmark-new.png')]" "xpath_element" should exist
+    Then "bookmark-new.png" "block_thumblinks_action > Link with Background" should exist
     And I configure the "Trainings" block
     # The "((//html//input[./@id = substring-before(//p[normalize-space(.)='Thumbnail 2 Image']/@id, '_label')]//ancestor::*[@data-fieldtype = 'filemanager' or @data-fieldtype = 'filepicker'])[1]/descendant-or-self::div[@class and contains(concat(' ', normalize-space(@class), ' '), ' fp-btn-add ')]/descendant-or-self::*/a | (//html//input[./@id = substring-before(//p[normalize-space(.)='Thumbnail 2 Image']/@id, '_label')]//ancestor::*[@data-fieldtype = 'filemanager' or @data-fieldtype = 'filepicker'])[1]/descendant-or-self::input[@class and contains(concat(' ', normalize-space(@class), ' '), ' fp-btn-choose ')])[1]"
       # xpath node is not visible and it should be visible.
     And I upload "blocks/thumblinks_action/tests/fixtures/document-edit.png" file to "Thumbnail 2 Image" filemanager
     When I press "Save changes"
-    Then "//*[contains(@class, 'block-thumblinks-action')]//a[2][contains(@style, 'document-edit.png')]" "xpath_element" should exist
+    Then "document-edit.png" "block_thumblinks_action > Link with Background" should exist

--- a/tests/block_thumblinks_action_test.php
+++ b/tests/block_thumblinks_action_test.php
@@ -22,9 +22,15 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use block_thumblinks_action\output\thumblinks_action;
+namespace block_thumblinks_action;
 
-defined('MOODLE_INTERNAL') || die();
+use advanced_testcase;
+use block_base;
+use block_thumblinks_action\output\thumblinks_action;
+use context_system;
+use context_user;
+use moodle_page;
+use stdClass;
 
 /**
  * Unit tests for block_thumblinks_action
@@ -33,25 +39,19 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class block_thumblinks_action_test extends advanced_testcase {
-
-    /**
-     * Current block
-     *
-     * @var block_base|false|null
-     */
+    /** @var block_base|false|null Current block */
     protected $block = null;
-    /**
-     * Current user
-     *
-     * @var stdClass|null
-     */
+
+    /** @var stdClass|null Current user. */
     protected $user = null;
 
     /**
      * Basic setup for these tests.
+     *
+     * @return void
      */
-    public function setUp() {
-        $this->resetAfterTest(true);
+    public function setUp(): void {
+        $this->resetAfterTest();
         $this->user = $this->getDataGenerator()->create_user();
         $this->setUser($this->user);
         // Create a Sponsor block.
@@ -83,22 +83,26 @@ class block_thumblinks_action_test extends advanced_testcase {
 
     /**
      * Test that output is as expected. This also test file loading into the plugin.
+     *
+     * @covers \block_thumblinks_action::get_content
      */
     public function test_simple_content() {
         // We need to reload the block so config is there.
         $block = block_instance_by_id($this->block->instance->id);
         $content = $block->get_content();
         $this->assertNotNull($content->text);
-        $this->assertContains('background-image: url(https://www.example.com/moodle/pluginfile.php/', $content->text);
-        $this->assertContains('block_thumblinks_action/images/0/img1.png', $content->text);
-        $this->assertContains('block_thumblinks_action/images/1/img2.png', $content->text);
-        $this->assertContains('Title 0', $content->text);
-        $this->assertContains('Title 1', $content->text);
-        $this->assertContains('Moodle forever', $content->text);
+        self::assertTrue((bool) strpos($content->text, 'background-image: url(https://www.example.com/moodle/pluginfile.php/'));
+        self::assertTrue((bool) strpos($content->text, 'block_thumblinks_action/images/0/img1.png'));
+        self::assertTrue((bool) strpos($content->text, 'block_thumblinks_action/images/1/img2.png'));
+        self::assertTrue((bool) strpos($content->text, 'Title 0'));
+        self::assertTrue((bool) strpos($content->text, 'Title 1'));
+        self::assertTrue((bool) strpos($content->text, 'Moodle forever'));
     }
 
     /**
      * Test that output is as expected. This also test file loading into the plugin.
+     *
+     * @covers \block_thumblinks_action\output\thumblinks_action::export_for_template
      */
     public function test_output_renderer_change_files() {
         // We need to reload the block so config is there.
@@ -122,14 +126,11 @@ class block_thumblinks_action_test extends advanced_testcase {
      * Upload a file/image in the block
      *
      * @param array $imagesnames
-     * @throws file_exception
-     * @throws stored_file_creation_exception
      */
     protected function upload_files_in_block($imagesnames) {
         global $CFG;
         $block = block_instance_by_id($this->block->instance->id);
         $usercontext = context_user::instance($this->user->id);
-        $files = [];
         $configdata = (object) [
             'title' => 'block title',
             'cta' => 'https://www.moodle.org',
@@ -149,8 +150,10 @@ class block_thumblinks_action_test extends advanced_testcase {
             // Create an area to upload the file.
             $fs = get_file_storage();
             // Create a file from the string that we made earlier.
-            $file = $fs->create_file_from_pathname($filerecord,
-                $CFG->dirroot . '/blocks/thumblinks_action/tests/fixtures/bookmark-new.png');
+            $file = $fs->create_file_from_pathname(
+                $filerecord,
+                $CFG->dirroot . '/blocks/thumblinks_action/tests/fixtures/bookmark-new.png'
+            );
             $configdata->thumbtitle[] = 'Title ' . $index;
             $configdata->thumburl[] = 'http://moodle.com/' . $index;
             $configdata->thumbimage[] = $file->get_itemid();
@@ -158,4 +161,3 @@ class block_thumblinks_action_test extends advanced_testcase {
         $block->instance_config_save((object) $configdata);
     }
 }
-

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2013011301;        // The current plugin version (Date: YYYYMMDDXX)
-$plugin->requires  = 2012112900;        // Requires this Moodle version
+$plugin->version   = 2022111002;                // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires  = 2012112900;                // Requires this Moodle version.
 $plugin->component = 'block_thumblinks_action'; // Full name of the plugin (used for diagnostics).
 $plugin->cron = 300;


### PR DESCRIPTION
* Add locator to make behat test more readable
* Do not click on the link but check the destination url instead
* Remove duplicated I turn editing mode on on the home page (it exists already in Moodle 3.x and 4.x)
* Fix issue with block edition in which draftitemid should explicitely be set to null so to avoid duplicating the file (if not the same file is duplicated in each thumbnails).